### PR TITLE
マップセレクター機能の実装とレイアウト調整

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -115,6 +115,14 @@ export default withNuxt([
       'vue/valid-define-props': 'error',
       'vue/valid-define-emits': 'error',
       'vue/require-explicit-emits': 'error',
+      'vue/html-self-closing': [
+        'error',
+        {
+          html: {
+            void: 'any',
+          },
+        },
+      ],
     },
   },
   {

--- a/src/assets/style/_variables.scss
+++ b/src/assets/style/_variables.scss
@@ -8,6 +8,7 @@ $color-gray-background: #f5f5f5;
 $color-gray-line-normal: #cccccc;
 
 $color-background: #111111;
+$color-background-light: #555761;
 
 // テーマカラー
 $color-primary: #3498db;

--- a/src/composables/useMapZoom.ts
+++ b/src/composables/useMapZoom.ts
@@ -1,0 +1,25 @@
+import { ref } from 'vue';
+
+export default function useMapZoom() {
+  // 拡大縮小の倍率を管理するref
+  const scale = ref(1);
+  const minScale = 0.5;
+  const maxScale = 3;
+
+  // マウスホイールイベントのハンドラー
+  const handleWheel = (event: WheelEvent) => {
+    // デフォルトスクロール動作を防止
+    event.preventDefault();
+
+    // wheelDeltaの変化量に基づいて拡大縮小を調整
+    // 下にスクロール（正の値）→拡大、上にスクロール（負の値）→縮小
+    const delta = event.deltaY > 0 ? -0.1 : 0.1;
+    const newScale = Math.max(minScale, Math.min(maxScale, scale.value + delta));
+    scale.value = newScale;
+  };
+
+  return {
+    scale,
+    handleWheel,
+  };
+}

--- a/src/layouts/withHeader.vue
+++ b/src/layouts/withHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="layout">
     <DefaultHeader />
     <NuxtPage />
   </div>
@@ -8,3 +8,11 @@
 <script setup lang="ts">
 import DefaultHeader from '@/uiParts/DefaultHeader.vue';
 </script>
+
+<style lang="scss" scoped>
+.layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+</style>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import MapSection from '@/uiParts/mapSelector/MapSection.vue';
 import { definePageMeta } from '~~/.nuxt/imports';
-import Button from '@/uiParts/Button.vue';
 
 definePageMeta({
   layout: 'with-header',
@@ -8,45 +8,22 @@ definePageMeta({
 </script>
 
 <template>
-  <div class="container">
-    <h1>Valorantアプリケーション</h1>
-    <p>このアプリはValorantに関する情報を提供します</p>
-
-    <div class="button-container">
-      <Button primary>プライマリーボタン</Button>
-      <Button>セカンダリーボタン</Button>
-      <Button small>小さいボタン</Button>
+  <div class="page">
+    <div class="page__left" />
+    <div class="page__center">
+      <MapSection />
     </div>
-
-    <div class="scss-example">
-      <h2>SCSSサンプル</h2>
-    </div>
+    <div class="page__right" />
   </div>
 </template>
 
 <style lang="scss" scoped>
-.container {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 2rem;
-}
-
-.button-container {
+.page {
   display: flex;
-  gap: 1rem;
-  margin-top: 2rem;
-}
+  height: 100%;
 
-h1 {
-  color: #4f46e5;
-  margin-bottom: 1rem;
-}
-
-.scss-example {
-  margin-top: 2rem;
-
-  h2 {
-    margin-bottom: 1rem;
+  &__center {
+    flex: 1;
   }
 }
 </style>

--- a/src/pages/map/abyss.vue
+++ b/src/pages/map/abyss.vue
@@ -1,0 +1,243 @@
+<script setup lang="ts">
+import MapLeftMenu from '@/uiParts/MapLeftMenu.vue';
+import { definePageMeta } from '~~/.nuxt/imports';
+import useMapZoom from '@/composables/useMapZoom';
+import { ref, computed } from 'vue';
+
+definePageMeta({
+  layout: 'with-header',
+});
+
+// ズーム機能のComposableを使用
+const { scale, handleWheel } = useMapZoom();
+
+// 赤い点のデータ配列（位置はマップに対する相対位置 0-100%）
+const redPoints = ref([
+  { id: 1, x: 20, y: 30, name: 'ポイントA' },
+  { id: 2, x: 60, y: 70, name: 'ポイントB' },
+  { id: 3, x: 40, y: 50, name: 'ポイントC' },
+]);
+
+// 青い点のデータ配列（各青い点は関連する赤い点のIDを持つ）
+const bluePoints = ref([
+  { id: 1, redPointId: 1, x: 30, y: 35, name: '子ポイントA1' },
+  { id: 2, redPointId: 1, x: 25, y: 40, name: '子ポイントA2' },
+  { id: 3, redPointId: 2, x: 70, y: 65, name: '子ポイントB1' },
+  { id: 4, redPointId: 2, x: 65, y: 80, name: '子ポイントB2' },
+  { id: 5, redPointId: 3, x: 50, y: 55, name: '子ポイントC1' },
+]);
+
+// 現在ホバーしている赤い点のID
+const hoveredRedPointId = ref<number | null>(null);
+// 現在ホバーしている青い点のID
+const hoveredBluePointId = ref<number | null>(null);
+
+// 表示する青い点
+const visibleBluePoints = computed(() => {
+  // 青い点にホバーしている場合は、そのホバーした青い点のみを表示
+  if (hoveredBluePointId.value) {
+    return bluePoints.value.filter(point => point.id === hoveredBluePointId.value);
+  }
+  // 赤い点にホバーしている場合は、その赤い点に紐づく青い点を表示
+  if (hoveredRedPointId.value) {
+    return bluePoints.value.filter(point => point.redPointId === hoveredRedPointId.value);
+  }
+  // どちらにもホバーしていない場合は全ての青い点を表示
+  return bluePoints.value;
+});
+
+// 表示する赤い点
+const visibleRedPoints = computed(() => {
+  // 青い点にホバーしている場合は、その青い点に紐づく赤い点のみを表示
+  if (hoveredBluePointId.value) {
+    const hoveredBluePoint = bluePoints.value.find(point => point.id === hoveredBluePointId.value);
+    if (hoveredBluePoint) {
+      return redPoints.value.filter(point => point.id === hoveredBluePoint.redPointId);
+    }
+  }
+  // それ以外の場合は全ての赤い点を表示
+  return redPoints.value;
+});
+
+// 青い点にホバーした時の処理
+const handleBluePointHover = (pointId: number) => {
+  hoveredBluePointId.value = pointId;
+  hoveredRedPointId.value = null; // 赤い点のホバー状態をクリア
+};
+
+// 青い点からホバーが外れた時の処理
+const handleBluePointLeave = () => {
+  hoveredBluePointId.value = null;
+};
+
+// 赤い点にホバーした時の処理
+const handleRedPointHover = (pointId: number) => {
+  hoveredRedPointId.value = pointId;
+  hoveredBluePointId.value = null; // 青い点のホバー状態をクリア
+};
+
+// 赤い点からホバーが外れた時の処理
+const handleRedPointLeave = () => {
+  hoveredRedPointId.value = null;
+};
+
+// 接続線を表示するかどうかの判定
+const showConnections = computed(() => {
+  return (
+    (hoveredRedPointId.value &&
+      visibleBluePoints.value.some(bp => bp.redPointId === hoveredRedPointId.value)) ||
+    (hoveredBluePointId.value && visibleRedPoints.value.length > 0)
+  );
+});
+
+// 接続線の開始点と終点を取得
+const getLinePoints = computed(() => {
+  if (hoveredBluePointId.value) {
+    // 青い点にホバーしている場合
+    const bluePoint = bluePoints.value.find(bp => bp.id === hoveredBluePointId.value);
+    if (!bluePoint) return [];
+
+    const redPoint = redPoints.value.find(rp => rp.id === bluePoint.redPointId);
+    if (!redPoint) return [];
+
+    return [
+      {
+        x1: redPoint.x,
+        y1: redPoint.y,
+        x2: bluePoint.x,
+        y2: bluePoint.y,
+      },
+    ];
+  } else if (hoveredRedPointId.value) {
+    // 赤い点にホバーしている場合
+    const redPoint = redPoints.value.find(rp => rp.id === hoveredRedPointId.value);
+    if (!redPoint) return [];
+
+    return visibleBluePoints.value
+      .filter(bp => bp.redPointId === hoveredRedPointId.value)
+      .map(bp => ({
+        x1: redPoint.x,
+        y1: redPoint.y,
+        x2: bp.x,
+        y2: bp.y,
+      }));
+  }
+
+  return [];
+});
+</script>
+
+<template>
+  <div class="page">
+    <div class="page__left">
+      <MapLeftMenu />
+    </div>
+    <div class="page__main" @wheel.prevent="handleWheel">
+      <div class="page__map-container" :style="{ transform: `scale(${scale})` }">
+        <img src="https://placehold.jp/1000x1000.png" alt="map" class="page__map" />
+
+        <!-- 赤い点 -->
+        <div
+          v-for="point in visibleRedPoints"
+          :key="`red-${point.id}`"
+          class="map-point map-point--red"
+          :style="{ left: `${point.x}%`, top: `${point.y}%` }"
+          :title="point.name"
+          @mouseenter="handleRedPointHover(point.id)"
+          @mouseleave="handleRedPointLeave"
+        />
+
+        <!-- 青い点 -->
+        <div
+          v-for="point in visibleBluePoints"
+          :key="`blue-${point.id}`"
+          class="map-point map-point--blue"
+          :style="{ left: `${point.x}%`, top: `${point.y}%` }"
+          :title="point.name"
+          @mouseenter="handleBluePointHover(point.id)"
+          @mouseleave="handleBluePointLeave"
+        />
+
+        <!-- 赤い点と青い点を結ぶ線（SVGで実装） -->
+        <svg v-if="showConnections" class="map-connections">
+          <line
+            v-for="(line, index) in getLinePoints"
+            :key="`line-${index}`"
+            :x1="`${line.x1}%`"
+            :y1="`${line.y1}%`"
+            :x2="`${line.x2}%`"
+            :y2="`${line.y2}%`"
+            class="connection-line"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.page {
+  display: flex;
+  height: 100%;
+
+  &__left {
+    width: 300px;
+    height: 100%;
+    background-color: $color-background-light;
+  }
+
+  &__main {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__map-container {
+    position: relative;
+    transition: transform 0.1s ease;
+    transform-origin: center;
+  }
+
+  &__map {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+}
+
+.map-point {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+
+  &--red {
+    background-color: red;
+    z-index: 2;
+  }
+
+  &--blue {
+    background-color: blue;
+    z-index: 1;
+  }
+}
+
+.map-connections {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.connection-line {
+  stroke: yellow;
+  stroke-width: 2px;
+  z-index: 0;
+}
+</style>

--- a/src/uiParts/MapLeftMenu.vue
+++ b/src/uiParts/MapLeftMenu.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import AgentCard from './agentSelector/AgentCard.vue';
+
+type Agent = {
+  name: string;
+  image: string;
+};
+
+const agents: Agent[] = [
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+  {
+    name: 'エージェント1',
+    image: 'https://placehold.jp/150x150.png',
+  },
+];
+</script>
+
+<template>
+  <div>
+    <p>キャラ選択</p>
+    <div class="agent-card-container">
+      <AgentCard
+        v-for="agent in agents"
+        :key="agent.name"
+        :agent-name="agent.name"
+        :agent-image="agent.image"
+        class="agent-card-container__card"
+      />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.agent-card-container {
+  &__card {
+    display: inline-block;
+    margin: 10px;
+  }
+}
+</style>

--- a/src/uiParts/agentSelector/AgentCard.vue
+++ b/src/uiParts/agentSelector/AgentCard.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+defineProps<{
+  agentName: string;
+  agentImage: string;
+}>();
+</script>
+
+<template>
+  <div class="agent-card">
+    <img :src="agentImage" alt="agent" />
+    <p class="agent-card__name">{{ agentName }}</p>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.agent-card {
+  position: relative;
+  width: 65px;
+  height: 65px;
+
+  &__name {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    font-size: 10px;
+    text-align: center;
+  }
+}
+</style>

--- a/src/uiParts/mapSelector/MapCard.vue
+++ b/src/uiParts/mapSelector/MapCard.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+defineProps<{
+  mapName: string;
+  mapImage: string;
+}>();
+</script>
+
+<template>
+  <div class="map-card">
+    <img :src="mapImage" alt="map" />
+    <p class="map-card__name">{{ mapName }}</p>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.map-card {
+  position: relative;
+  width: fit-content;
+  cursor: pointer;
+  &__name {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: fit-content;
+    text-align: center;
+    margin: 0 auto;
+  }
+}
+</style>

--- a/src/uiParts/mapSelector/MapSection.vue
+++ b/src/uiParts/mapSelector/MapSection.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import MapCard from '@/uiParts/mapSelector/MapCard.vue';
+import type { RouteLocationRaw } from 'vue-router';
+
+type Map = {
+  name: string;
+  image: string;
+  page: RouteLocationRaw;
+};
+
+const maps: Map[] = [
+  {
+    name: 'Abyss',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'Ascent',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'bind',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'Breeze',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'Fracture',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'Haven',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'Icebox',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'Lotus',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'Pearl',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'Split',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+  {
+    name: 'Sunset',
+    image: 'https://placehold.jp/150x150.png',
+    page: { name: 'map-abyss' },
+  },
+];
+
+const moveToMapPage = (map: Map) => {
+  navigateTo(map.page);
+};
+</script>
+
+<template>
+  <div class="map-section">
+    <MapCard
+      v-for="map in maps"
+      :key="map.name"
+      :map-name="map.name"
+      :map-image="map.image"
+      class="map-section__card"
+      @click="moveToMapPage(map)"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.map-section {
+  display: flex;
+  flex-wrap: wrap;
+}
+</style>


### PR DESCRIPTION
## 変更内容

### 新機能
- マップセレクター機能の実装
- マップページ（abyss.vue）の追加
- エージェントセレクター用のコンポーネント追加

### UI変更
- トップページを3カラムレイアウトに変更
- レイアウトコンポーネントにフレックスボックスを適用
- MapSectionコンポーネントをトップページに追加

### 技術的変更
- マップズーム機能用のcomposableを追加
- SCSS変数に背景色用の変数追加（$color-background-light）
- ESLintルールの追加（vue/html-self-closing）

### 影響範囲
- トップページのレイアウトが完全に変更されています
- 新しいマップページが追加されています

### テスト内容
- トップページでのマップセレクターの表示確認
- マップページでのレイアウト確認
