### PR TITLE
トップページのヘッダー高さ調整

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -34,7 +34,7 @@ definePageMeta({
 <style lang="scss" scoped>
 .page {
   display: flex;
-  height: 100%;
+  height: calc(100% - 72px);
 
   &__center {
     flex: 1;

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -34,6 +34,7 @@ definePageMeta({
 <style lang="scss" scoped>
 .page {
   display: flex;
+  /* ヘッダーの高さ(72px)を引いて、コンテンツエリアの高さを調整 */
   height: calc(100% - 72px);
 
   &__center {


### PR DESCRIPTION
トップページとマップページのヘッダーの高さが微妙に違ったので統一した。